### PR TITLE
Enhance design and add problem filters

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +20,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -25,10 +15,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <header className="flex justify-end gap-4 p-4 border-b">
+      <body className="antialiased">
+        <header className="flex items-center justify-between p-4 border-b bg-gradient-to-r from-purple-600 to-violet-700 text-white">
+          <Link href="/" className="font-bold text-lg hover:underline">
+            Math Site
+          </Link>
           <nav className="flex gap-4">
             <Link href="/login" className="hover:underline">
               로그인

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,26 @@
 export default function Login() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-4">
-      <h1 className="text-2xl font-bold">로그인</h1>
-      <p>로그인 기능은 아직 구현되지 않았습니다.</p>
+    <div className="flex flex-col items-center justify-center min-h-screen gap-8 p-4 bg-gradient-to-br from-purple-50 to-white">
+      <h1 className="text-3xl font-bold">로그인</h1>
+      <div className="grid w-full max-w-md grid-cols-1 gap-6 md:grid-cols-2">
+        <form className="flex flex-col gap-3 rounded border p-4 shadow">
+          <h2 className="text-xl font-semibold mb-2">회원가입</h2>
+          <input type="text" placeholder="아이디" className="border p-2 rounded" />
+          <input type="email" placeholder="이메일" className="border p-2 rounded" />
+          <input type="password" placeholder="비밀번호" className="border p-2 rounded" />
+          <button type="submit" className="mt-2 rounded bg-purple-600 py-2 text-white hover:bg-purple-700">
+            가입하기
+          </button>
+        </form>
+        <form className="flex flex-col gap-3 rounded border p-4 shadow">
+          <h2 className="text-xl font-semibold mb-2">로그인</h2>
+          <input type="text" placeholder="아이디" className="border p-2 rounded" />
+          <input type="password" placeholder="비밀번호" className="border p-2 rounded" />
+          <button type="submit" className="mt-2 rounded bg-violet-600 py-2 text-white hover:bg-violet-700">
+            로그인
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,11 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <main className="flex flex-col justify-between min-h-screen p-4">
+    <main className="flex flex-col justify-between min-h-screen p-4 bg-gradient-to-br from-white to-purple-50">
       <div className="flex flex-col items-center justify-center flex-1 gap-6 text-center">
-        <h1 className="text-3xl font-bold">수학 학습 사이트</h1>
+        <h1 className="text-4xl font-bold tracking-tight">수학 학습 사이트</h1>
         <Image src="/next.svg" alt="logo" width={180} height={38} className="dark:invert" />
-        <p className="max-w-md">
+        <p className="max-w-md text-lg">
           이 웹사이트는 다양한 수학 문제와 설명을 제공하여 학습을 돕기 위한 곳입니다.
         </p>
       </div>
@@ -14,7 +14,7 @@ export default function Home() {
         <input
           type="text"
           placeholder="프롬프트를 입력하세요"
-          className="border rounded p-2 w-full max-w-md"
+          className="border rounded p-2 w-full max-w-md shadow"
         />
       </div>
     </main>

--- a/src/app/problems/page.tsx
+++ b/src/app/problems/page.tsx
@@ -1,8 +1,51 @@
+"use client";
+import { useState, useMemo } from "react";
+import Image from "next/image";
+
 export default function Problems() {
+  const [grade, setGrade] = useState<string>("");
+  const [level, setLevel] = useState<string>("");
+
+  const imgSrc = useMemo(() => {
+    if (!grade || !level) return null;
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='300' height='160'>` +
+      `<rect width='300' height='160' fill='#ede9fe'/>` +
+      `<text x='150' y='80' font-size='24' text-anchor='middle' dominant-baseline='middle' fill='#4c1d95'>${grade}학년 ${level}</text>` +
+      `</svg>`;
+    return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+  }, [grade, level]);
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-4">
-      <h1 className="text-2xl font-bold">문제 모음</h1>
-      <p>여기에 수학 문제가 표시됩니다.</p>
+    <div className="flex flex-col items-center min-h-screen gap-6 p-4 bg-gradient-to-br from-white to-purple-50">
+      <h1 className="text-3xl font-bold">문제 모음</h1>
+      <div className="flex gap-4">
+        <select
+          value={grade}
+          onChange={(e) => setGrade(e.target.value)}
+          className="border rounded p-2"
+        >
+          <option value="">학년 선택</option>
+          <option value="1">1학년</option>
+          <option value="2">2학년</option>
+          <option value="3">3학년</option>
+          <option value="4">4학년</option>
+          <option value="5">5학년</option>
+          <option value="6">6학년</option>
+        </select>
+        <select
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+          className="border rounded p-2"
+        >
+          <option value="">난이도 선택</option>
+          <option value="쉬움">쉬움</option>
+          <option value="보통">보통</option>
+          <option value="어려움">어려움</option>
+        </select>
+      </div>
+      {imgSrc && (
+        <Image src={imgSrc} alt="문제 태그" width={300} height={160} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- modernize the header and use a gradient background
- improve the home page style
- add signup and login forms
- implement grade/difficulty selector with preview image
- drop remote fonts for offline builds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685603a8e918832e988f1e6515b14e17