### PR TITLE
Fix Firebase init error during prerender

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { FirebaseError } from "firebase/app";
-import { auth } from "@/firebase";
+import { getAuthClient } from "@/firebase";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -15,6 +15,10 @@ export default function Login() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
+      const auth = getAuthClient();
+      if (!auth) {
+        throw new Error("Firebase configuration missing");
+      }
       await signInWithEmailAndPassword(auth, email, password);
       router.push("/");
     } catch (error: unknown) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createUserWithEmailAndPassword } from "firebase/auth";
 import { FirebaseError } from "firebase/app";
-import { auth } from "@/firebase";
+import { getAuthClient } from "@/firebase";
 
 export default function Signup() {
   const [email, setEmail] = useState("");
@@ -15,6 +15,10 @@ export default function Signup() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
+      const auth = getAuthClient();
+      if (!auth) {
+        throw new Error("Firebase configuration missing");
+      }
       await createUserWithEmailAndPassword(auth, email, password);
       router.push("/");
     } catch (error: unknown) {

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,22 +1,42 @@
-import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
+import { FirebaseApp, getApp, getApps, initializeApp } from "firebase/app";
+import { getAnalytics, isSupported } from "firebase/analytics";
 import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "",
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "",
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "",
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "",
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "",
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "",
-  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID ?? ""
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
 };
 
-const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
+let app: FirebaseApp | null = null;
+
+export const getFirebaseApp = (): FirebaseApp | null => {
+  if (app) return app;
+  if (!firebaseConfig.apiKey) {
+    return null;
+  }
+  app = getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);
+  return app;
+};
+
+export const getAuthClient = () => {
+  const firebaseApp = getFirebaseApp();
+  return firebaseApp ? getAuth(firebaseApp) : null;
+};
 
 if (typeof window !== "undefined") {
-  getAnalytics(app);
+  const firebaseApp = getFirebaseApp();
+  if (firebaseApp) {
+    isSupported().then((supported) => {
+      if (supported) {
+        getAnalytics(firebaseApp);
+      }
+    });
+  }
 }
 
-export default app;
+export default getFirebaseApp;


### PR DESCRIPTION
## Summary
- initialize Firebase lazily so build doesn't fail when env vars are missing
- adjust login and signup pages to fetch Auth instance at runtime

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856138da5a4832e83a8eb19941691aa